### PR TITLE
[feat]: 상단 페이지 이동 및 스크롤 진행률 프로그레스바 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "notion-client": "^6.16.0",
     "notion-types": "^6.16.0",
     "notion-utils": "^6.16.0",
+    "nprogress": "^0.2.0",
     "prismjs": "^1.29.0",
     "react": "^18.2.0",
     "react-cusdis": "^2.1.3",
@@ -35,6 +36,7 @@
   "devDependencies": {
     "@types/gtag.js": "^0.0.12",
     "@types/node": "^18.11.15",
+    "@types/nprogress": "^0.2.3",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",
     "autoprefixer": "^10.4.0",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,16 +2,60 @@ import { AppPropsWithLayout } from "../types"
 import { Hydrate, QueryClientProvider } from "@tanstack/react-query"
 import { RootLayout } from "src/layouts"
 import { queryClient } from "src/libs/react-query"
+import NProgress from "nprogress"
+import "nprogress/nprogress.css"
+import { useEffect } from "react"
+import { useRouter } from "next/router"
+import { Global, css } from "@emotion/react"
 
 function App({ Component, pageProps }: AppPropsWithLayout) {
   const getLayout = Component.getLayout || ((page) => page)
+  const router = useRouter()
+
+  useEffect(() => {
+    const handleStart = () => NProgress.start()
+    const handleStop = () => NProgress.done()
+    router.events.on("routeChangeStart", handleStart)
+    router.events.on("routeChangeComplete", handleStop)
+    router.events.on("routeChangeError", handleStop)
+    return () => {
+      router.events.off("routeChangeStart", handleStart)
+      router.events.off("routeChangeComplete", handleStop)
+      router.events.off("routeChangeError", handleStop)
+    }
+  }, [router])
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <Hydrate state={pageProps.dehydratedState}>
-        <RootLayout>{getLayout(<Component {...pageProps} />)}</RootLayout>
-      </Hydrate>
-    </QueryClientProvider>
+    <>
+      <Global
+        styles={css`
+          /* nprogress 커스텀 */
+          #nprogress {
+            pointer-events: none;
+          }
+          #nprogress .bar {
+            background: #6366f1;
+            position: fixed;
+            z-index: 1031;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 3px;
+          }
+          #nprogress .peg {
+            display: none;
+          }
+          #nprogress .spinner {
+            display: none;
+          }
+        `}
+      />
+      <QueryClientProvider client={queryClient}>
+        <Hydrate state={pageProps.dehydratedState}>
+          <RootLayout>{getLayout(<Component {...pageProps} />)}</RootLayout>
+        </Hydrate>
+      </QueryClientProvider>
+    </>
   )
 }
 

--- a/src/routes/Detail/PostDetail/index.tsx
+++ b/src/routes/Detail/PostDetail/index.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useEffect, useState } from "react"
 import PostHeader from "./PostHeader"
 import Footer from "./PostFooter"
 import CommentBox from "./CommentBox"
@@ -6,6 +6,41 @@ import Category from "src/components/Category"
 import styled from "@emotion/styled"
 import NotionRenderer from "../components/NotionRenderer"
 import usePostQuery from "src/hooks/usePostQuery"
+
+// 스크롤 프로그레스바 컴포넌트
+const ScrollProgressBar = () => {
+  const [progress, setProgress] = useState(0)
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollTop = window.scrollY
+      const docHeight = document.documentElement.scrollHeight - window.innerHeight
+      const percent = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0
+      setProgress(percent)
+    }
+    window.addEventListener("scroll", handleScroll)
+    return () => window.removeEventListener("scroll", handleScroll)
+  }, [])
+  return (
+    <ProgressBarWrapper>
+      <ProgressBarInner style={{ width: `${progress}%` }} />
+    </ProgressBarWrapper>
+  )
+}
+
+const ProgressBarWrapper = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 4px;
+  background: transparent;
+  z-index: 2000;
+`
+const ProgressBarInner = styled.div`
+  height: 100%;
+  background: #6366f1;
+  transition: width 0.2s;
+`
 
 type Props = {}
 
@@ -18,6 +53,7 @@ const PostDetail: React.FC<Props> = () => {
 
   return (
     <StyledWrapper>
+      <ScrollProgressBar />
       <article>
         {category && (
           <div css={{ marginBottom: "0.5rem" }}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -479,6 +479,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.15.tgz#de0e1fbd2b22b962d45971431e2ae696643d3f5d"
   integrity sha512-VkhBbVo2+2oozlkdHXLrb3zjsRkpdnaU2bXmX8Wgle3PUi569eLRaHGlgETQHR7lLL1w7GiG3h9SnePhxNDecw==
 
+"@types/nprogress@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@types/nprogress/-/nprogress-0.2.3.tgz#b2150b054a13622fabcba12cf6f0b54c48b14287"
+  integrity sha512-k7kRA033QNtC+gLc4VPlfnue58CM1iQLgn1IMAU8VPHGOj7oIHPp9UlhedEnD/Gl8evoCjwkZjlBORtZ3JByUA==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -3230,6 +3235,11 @@ npm-run-path@^5.1.0:
   integrity sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==
   dependencies:
     path-key "^4.0.0"
+
+nprogress@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/nprogress/-/nprogress-0.2.0.tgz#cb8f34c53213d895723fcbab907e9422adbcafb1"
+  integrity sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==
 
 object-assign@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
## Description

- **페이지 이동 시** 상단에 nprogress를 활용한 로딩 프로그레스바를 추가했습니다.
  - 라우팅이 시작되면 보라색 얇은 바가 상단에 표시되고, 완료 시 사라집니다.
- **글 상세 페이지(PostDetail)**에서 스크롤 진행률을 보여주는 상단 프로그레스바를 추가했습니다.
  - 사용자가 글을 얼마나 읽었는지 직관적으로 확인할 수 있습니다.
- 두 프로그레스바 모두 색상은 #6366f1(보라색)으로 통일했습니다.
- 스타일 및 위치는 추후 요청에 따라 쉽게 커스텀 가능합니다.

**리뷰 가이드**
- 페이지 이동 시와 글 상세 페이지에서 상단 프로그레스바가 정상적으로 동작하는지 확인해 주세요.
- 스타일이나 UX 관련 추가 의견이 있으면 코멘트 부탁드립니다.

**시각적 참고**
- (필요하다면 스크린샷이나 짧은 gif 첨부)

---

## Related tickets

https://github.com/morethanmin/morethan-log/issues/XX

---

## PR Checklist

- [x] I have read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I have written documents and tests, if needed.

---

필요에 따라 관련 이슈 번호(XX)만 실제 이슈 번호로 바꿔서 사용하시면 됩니다!  
추가로 원하는 내용이 있으면 말씀해 주세요.
