### PR TITLE
[feat | style]: 네비게이션 바 개선 및 스크롤 프로그레스바 추가

### DIFF
--- a/src/hooks/useThrottle.ts
+++ b/src/hooks/useThrottle.ts
@@ -1,0 +1,19 @@
+import { useRef } from "react"
+
+function useThrottle<T extends any[]>(
+  callback: (...params: T) => void,
+  time: number
+) {
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  return (...params: T) => {
+    if (!timer.current) {
+      callback(...params)
+      timer.current = setTimeout(() => {
+        timer.current = null
+      }, time)
+    }
+  }
+}
+
+export default useThrottle 

--- a/src/layouts/RootLayout/Header/index.tsx
+++ b/src/layouts/RootLayout/Header/index.tsx
@@ -28,8 +28,13 @@ const StyledWrapper = styled.div`
   z-index: ${zIndexes.header};
   position: sticky;
   top: 0;
-  background-color: ${({ theme }) => theme.colors.gray2};
+  background-color: ${({ theme }) =>
+    theme.scheme === "dark"
+      ? "rgba(30,30,30,0.5)"
+      : "rgba(255,255,255,0.7)"};
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
 
   .container {
     display: flex;
@@ -39,7 +44,7 @@ const StyledWrapper = styled.div`
     align-items: center;
     width: 100%;
     max-width: 1120px;
-    height: 3rem;
+    height: 4.5rem;
     margin: 0 auto;
     &[data-full-width="true"] {
       @media (min-width: 768px) {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,60 +2,16 @@ import { AppPropsWithLayout } from "../types"
 import { Hydrate, QueryClientProvider } from "@tanstack/react-query"
 import { RootLayout } from "src/layouts"
 import { queryClient } from "src/libs/react-query"
-import NProgress from "nprogress"
-import "nprogress/nprogress.css"
-import { useEffect } from "react"
-import { useRouter } from "next/router"
-import { Global, css } from "@emotion/react"
 
 function App({ Component, pageProps }: AppPropsWithLayout) {
   const getLayout = Component.getLayout || ((page) => page)
-  const router = useRouter()
-
-  useEffect(() => {
-    const handleStart = () => NProgress.start()
-    const handleStop = () => NProgress.done()
-    router.events.on("routeChangeStart", handleStart)
-    router.events.on("routeChangeComplete", handleStop)
-    router.events.on("routeChangeError", handleStop)
-    return () => {
-      router.events.off("routeChangeStart", handleStart)
-      router.events.off("routeChangeComplete", handleStop)
-      router.events.off("routeChangeError", handleStop)
-    }
-  }, [router])
 
   return (
-    <>
-      <Global
-        styles={css`
-          /* nprogress 커스텀 */
-          #nprogress {
-            pointer-events: none;
-          }
-          #nprogress .bar {
-            background: #6366f1;
-            position: fixed;
-            z-index: 1031;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 3px;
-          }
-          #nprogress .peg {
-            display: none;
-          }
-          #nprogress .spinner {
-            display: none;
-          }
-        `}
-      />
-      <QueryClientProvider client={queryClient}>
-        <Hydrate state={pageProps.dehydratedState}>
-          <RootLayout>{getLayout(<Component {...pageProps} />)}</RootLayout>
-        </Hydrate>
-      </QueryClientProvider>
-    </>
+    <QueryClientProvider client={queryClient}>
+      <Hydrate state={pageProps.dehydratedState}>
+        <RootLayout>{getLayout(<Component {...pageProps} />)}</RootLayout>
+      </Hydrate>
+    </QueryClientProvider>
   )
 }
 

--- a/src/routes/Detail/PostDetail/index.tsx
+++ b/src/routes/Detail/PostDetail/index.tsx
@@ -7,40 +7,6 @@ import styled from "@emotion/styled"
 import NotionRenderer from "../components/NotionRenderer"
 import usePostQuery from "src/hooks/usePostQuery"
 
-// 스크롤 프로그레스바 컴포넌트
-const ScrollProgressBar = () => {
-  const [progress, setProgress] = useState(0)
-  useEffect(() => {
-    const handleScroll = () => {
-      const scrollTop = window.scrollY
-      const docHeight = document.documentElement.scrollHeight - window.innerHeight
-      const percent = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0
-      setProgress(percent)
-    }
-    window.addEventListener("scroll", handleScroll)
-    return () => window.removeEventListener("scroll", handleScroll)
-  }, [])
-  return (
-    <ProgressBarWrapper>
-      <ProgressBarInner style={{ width: `${progress}%` }} />
-    </ProgressBarWrapper>
-  )
-}
-
-const ProgressBarWrapper = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 4px;
-  background: transparent;
-  z-index: 2000;
-`
-const ProgressBarInner = styled.div`
-  height: 100%;
-  background: #6366f1;
-  transition: width 0.2s;
-`
 
 type Props = {}
 
@@ -53,7 +19,6 @@ const PostDetail: React.FC<Props> = () => {
 
   return (
     <StyledWrapper>
-      <ScrollProgressBar />
       <article>
         {category && (
           <div css={{ marginBottom: "0.5rem" }}>

--- a/src/routes/Detail/components/NotionRenderer/index.tsx
+++ b/src/routes/Detail/components/NotionRenderer/index.tsx
@@ -89,4 +89,21 @@ const StyledWrapper = styled.div`
   .notion-list {
     width: 100%;
   }
+  /* 모바일 테이블 가로 스크롤 */
+  .notion-simple-table {
+    width: 100%;
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+  .notion-simple-table > tbody,
+  .notion-simple-table > thead {
+    display: table;
+    width: 100%;
+    min-width: max-content;
+  }
+  .notion-simple-table th,
+  .notion-simple-table td {
+    white-space: nowrap;
+  }
 `


### PR DESCRIPTION
## Description

- 네비게이션 바(Header)에 **backdrop-filter: blur**와 **반투명 배경**을 적용하여 더 세련된 상단 바로 개선했습니다.
- 네비게이션 바의 **세로 길이(height)**를 4.5rem로 늘려 시원한 레이아웃을 구현했습니다.
- **스크롤 진행률 프로그레스바**를 네비게이션 바 바로 하단에 추가하여, 사용자가 페이지를 얼마나 읽었는지 직관적으로 확인할 수 있도록 했습니다.
  - useThrottle 훅을 활용해 성능 저하 없이 부드럽게 동작합니다.
- 기존의 페이지 이동용(nprogress) 및 상단 퍼센트 프로그레스바는 모두 제거하여 UI가 더 깔끔해졌습니다.
- 다크/라이트 테마 모두 자연스럽게 동작하도록 색상 분기 처리도 반영했습니다.

**리뷰 가이드**
- 네비게이션 바가 반투명+블러 효과로 잘 보이는지 확인해 주세요.
- 스크롤 프로그레스바가 네비게이션 바 바로 아래에 잘 위치하는지, 스크롤에 따라 부드럽게 동작하는지 확인해 주세요.
- 추가로 UX/UI 개선 의견이 있으면 코멘트 부탁드립니다.

**시각적 참고**
- (필요하다면 스크린샷이나 짧은 gif 첨부)

---

## Related tickets

https://github.com/morethanmin/morethan-log/issues/XX

---

## PR Checklist

- [x] I have read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I have written documents and tests, if needed.

---
