### PR TITLE
[feat]: 코드 블럭 스타일 개선

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "notion-types": "^7.4.2",
     "notion-utils": "^7.4.2",
     "nprogress": "^0.2.0",
+    "prism-material-themes": "^1.0.5",
     "prismjs": "^1.29.0",
     "react": "^18.2.0",
     "react-cusdis": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "react-cusdis": "^2.1.3",
     "react-dom": "^18.2.0",
     "react-icons": "^4.4.0",
-    "react-notion-x": "^7.4.2"
+    "react-notion-x": "^7.4.2",
+    "react-syntax-highlighter": "^15.6.1"
   },
   "devDependencies": {
     "@types/gtag.js": "^0.0.12",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import { AppPropsWithLayout } from "../types"
 import { Hydrate, QueryClientProvider } from "@tanstack/react-query"
 import { RootLayout } from "src/layouts"
 import { queryClient } from "src/libs/react-query"
+import "src/styles/table.css"
 
 function App({ Component, pageProps }: AppPropsWithLayout) {
   const getLayout = Component.getLayout || ((page) => page)

--- a/src/routes/Detail/components/NotionRenderer/index.tsx
+++ b/src/routes/Detail/components/NotionRenderer/index.tsx
@@ -9,6 +9,21 @@ import "react-notion-x/src/styles.css"
 
 // used for code syntax highlighting (optional)
 import "prismjs/themes/prism-tomorrow.css"
+// import "prismjs/components/prism-javascript"
+// import "prismjs/components/prism-typescript"
+// import "prismjs/components/prism-jsx"
+// import "prismjs/components/prism-tsx"
+// import "prismjs/components/prism-python"
+// import "prismjs/components/prism-markup"
+// import "prismjs/components/prism-bash"
+// import "prismjs/components/prism-json"
+// import "prismjs/components/prism-css"
+// import "prismjs/components/prism-scss"
+// import "prismjs/components/prism-java"
+// import "prismjs/components/prism-c"
+// import "prismjs/components/prism-cpp"
+// import "prismjs/components/prism-go"
+// import "prismjs/components/prism-rust"
 
 // used for rendering equations (optional)
 
@@ -113,5 +128,33 @@ const StyledWrapper = styled.div`
   }
   .notion-quote {
     font-size: 1rem;
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+  .notion-callout {
+    font-size: 1rem;
+    margin-top: 0.8rem;
+    margin-bottom: 0.8rem;
+  }
+  /* 인라인 코드가 길어질 때 좌우 스크롤 처리 */
+  .notion-inline-code {
+    display: inline-block;
+    max-width: 100%;
+    overflow-x: auto;
+    vertical-align: middle;
+    white-space: pre;
+    -webkit-overflow-scrolling: touch;
+  }
+    
+  /* 공통 코드 블럭 스타일 (가독성 향상) */
+  .notion-code {
+    font-family: 'Fira Mono', 'Menlo', 'Monaco', 'Consolas', monospace;
+    font-size: 0.8em;
+    border-radius: 6px;
+    margin: 1em 0;
+    padding: 1em;
+    overflow-x: auto;
+    /* 혹시 border가 필요하면 아래 추가 */
+    /* border: 1px solidrgb(67, 63, 96); */
   }
 `

--- a/src/routes/Detail/components/NotionRenderer/index.tsx
+++ b/src/routes/Detail/components/NotionRenderer/index.tsx
@@ -3,6 +3,10 @@ import Image from "next/image"
 import Link from "next/link"
 import { ExtendedRecordMap } from "notion-types"
 import useScheme from "src/hooks/useScheme"
+import { FC } from "react"
+import { Global } from "@emotion/react"
+import { notionCustomStyles } from "src/styles/notion-custom"
+import styled from "@emotion/styled"
 
 // core styles shared by all of react-notion-x (required)
 import "react-notion-x/src/styles.css"
@@ -28,8 +32,6 @@ import "prismjs/themes/prism-tomorrow.css"
 // used for rendering equations (optional)
 
 import "katex/dist/katex.min.css"
-import { FC } from "react"
-import styled from "@emotion/styled"
 
 const _NotionRenderer = dynamic(
   () => import("react-notion-x").then((m) => m.NotionRenderer),
@@ -72,89 +74,26 @@ type Props = {
 const NotionRenderer: FC<Props> = ({ recordMap }) => {
   const [scheme] = useScheme()
   return (
-    <StyledWrapper>
-      <_NotionRenderer
-        darkMode={scheme === "dark"}
-        recordMap={recordMap}
-        components={{
-          Code,
-          Collection,
-          Equation,
-          Modal,
-          Pdf,
-          nextImage: Image,
-          nextLink: Link,
-        }}
-        mapPageUrl={mapPageUrl}
-      />
-    </StyledWrapper>
+    <>
+      <Global styles={notionCustomStyles} />
+      <div>
+        <_NotionRenderer
+          darkMode={scheme === "dark"}
+          recordMap={recordMap}
+          components={{
+            Code,
+            Collection,
+            Equation,
+            Modal,
+            Pdf,
+            nextImage: Image,
+            nextLink: Link,
+          }}
+          mapPageUrl={mapPageUrl}
+        />
+      </div>
+    </>
   )
 }
 
 export default NotionRenderer
-
-const StyledWrapper = styled.div`
-  /* // TODO: why render? */
-  .notion-collection-page-properties {
-    display: none !important;
-  }
-  .notion-page {
-    padding: 0;
-  }
-  .notion-list {
-    width: 100%;
-  }
-  /* 모바일 테이블 가로 스크롤 */
-  .notion-simple-table {
-    width: 100%;
-    display: block;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    margin-top: 0.5rem;
-    margin-bottom: 0.5rem;
-  }
-  .notion-simple-table > tbody,
-  .notion-simple-table > thead {
-    display: table;
-    width: 100%;
-    min-width: max-content;
-  }
-  .notion-simple-table th,
-  .notion-simple-table td {
-    white-space: pre-wrap;
-    word-break: break-word;
-    padding: 8px;
-    vertical-align: top;
-  }
-  .notion-quote {
-    font-size: 1rem;
-    margin-top: 0.5rem;
-    margin-bottom: 0.5rem;
-  }
-  .notion-callout {
-    font-size: 1rem;
-    margin-top: 0.8rem;
-    margin-bottom: 0.8rem;
-  }
-  /* 인라인 코드가 길어질 때 좌우 스크롤 처리 */
-  .notion-inline-code {
-    display: inline-block;
-    max-width: 100%;
-    overflow-x: auto;
-    vertical-align: middle;
-    white-space: pre;
-    -webkit-overflow-scrolling: touch;
-  }
-    
-  /* 공통 코드 블럭 스타일 (가독성 향상) */
-  .notion-code {
-    font-family: 'Fira Mono', 'Menlo', 'Monaco', 'Consolas', monospace;
-    font-size: 0.8em;
-    border-radius: 6px;
-    margin: 1em 0;
-    padding: 1em;
-    overflow-x: auto;
-    /* 혹시 border가 필요하면 아래 추가 */
-    /* border: 1px solidrgb(67, 63, 96); */
-  }
-`

--- a/src/routes/Detail/components/NotionRenderer/index.tsx
+++ b/src/routes/Detail/components/NotionRenderer/index.tsx
@@ -106,7 +106,10 @@ const StyledWrapper = styled.div`
   }
   .notion-simple-table th,
   .notion-simple-table td {
-    white-space: nowrap;
+    white-space: pre-wrap;
+    word-break: break-word;
+    padding: 8px;
+    vertical-align: top;
   }
   .notion-quote {
     font-size: 1rem;

--- a/src/routes/Detail/components/NotionRenderer/index.tsx
+++ b/src/routes/Detail/components/NotionRenderer/index.tsx
@@ -3,34 +3,21 @@ import Image from "next/image"
 import Link from "next/link"
 import { ExtendedRecordMap } from "notion-types"
 import useScheme from "src/hooks/useScheme"
-import { FC } from "react"
+import { FC, useEffect } from "react"
 import { Global } from "@emotion/react"
 import { notionCustomStyles } from "src/styles/notion-custom"
 import styled from "@emotion/styled"
+
 
 // core styles shared by all of react-notion-x (required)
 import "react-notion-x/src/styles.css"
 
 // used for code syntax highlighting (optional)
-import "prismjs/themes/prism-tomorrow.css"
-// import "prismjs/components/prism-javascript"
-// import "prismjs/components/prism-typescript"
-// import "prismjs/components/prism-jsx"
-// import "prismjs/components/prism-tsx"
-// import "prismjs/components/prism-python"
-// import "prismjs/components/prism-markup"
-// import "prismjs/components/prism-bash"
-// import "prismjs/components/prism-json"
-// import "prismjs/components/prism-css"
-// import "prismjs/components/prism-scss"
-// import "prismjs/components/prism-java"
-// import "prismjs/components/prism-c"
-// import "prismjs/components/prism-cpp"
-// import "prismjs/components/prism-go"
-// import "prismjs/components/prism-rust"
+// import "prismjs/themes/prism-tomorrow.css"
+import 'prism-material-themes/themes/material-default.css';
+
 
 // used for rendering equations (optional)
-
 import "katex/dist/katex.min.css"
 
 const _NotionRenderer = dynamic(
@@ -73,6 +60,7 @@ type Props = {
 
 const NotionRenderer: FC<Props> = ({ recordMap }) => {
   const [scheme] = useScheme()
+
   return (
     <>
       <Global styles={notionCustomStyles} />

--- a/src/styles/notion-custom.ts
+++ b/src/styles/notion-custom.ts
@@ -51,15 +51,4 @@ export const notionCustomStyles = css`
     white-space: pre;
     -webkit-overflow-scrolling: touch;
   }
-  /* 공통 코드 블럭 스타일 (가독성 향상) */
-  .notion-code {
-    font-family: 'Fira Mono', 'Menlo', 'Monaco', 'Consolas', monospace;
-    font-size: 0.8em;
-    border-radius: 6px;
-    margin: 1em 0;
-    padding: 1em;
-    overflow-x: auto;
-    /* 혹시 border가 필요하면 아래 추가 */
-    /* border: 1px solidrgb(67, 63, 96); */
-  }
 `;

--- a/src/styles/notion-custom.ts
+++ b/src/styles/notion-custom.ts
@@ -1,0 +1,65 @@
+import { css } from "@emotion/react"
+
+export const notionCustomStyles = css`
+  .notion-collection-page-properties {
+    display: none !important;
+  }
+  .notion-page {
+    padding: 0;
+  }
+  .notion-list {
+    width: 100%;
+  }
+  /* 모바일 테이블 가로 스크롤 */
+  .notion-simple-table {
+    width: 100%;
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+  .notion-simple-table > tbody,
+  .notion-simple-table > thead {
+    display: table;
+    width: 100%;
+    min-width: max-content;
+  }
+  .notion-simple-table th,
+  .notion-simple-table td {
+    white-space: pre-wrap;
+    word-break: break-word;
+    padding: 8px;
+    vertical-align: top;
+  }
+  .notion-quote {
+    font-size: 1rem;
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+  .notion-callout {
+    font-size: 1rem;
+    margin-top: 0.8rem;
+    margin-bottom: 0.8rem;
+  }
+  /* 인라인 코드가 길어질 때 좌우 스크롤 처리 */
+  .notion-inline-code {
+    display: inline-block;
+    max-width: 100%;
+    overflow-x: auto;
+    vertical-align: middle;
+    white-space: pre;
+    -webkit-overflow-scrolling: touch;
+  }
+  /* 공통 코드 블럭 스타일 (가독성 향상) */
+  .notion-code {
+    font-family: 'Fira Mono', 'Menlo', 'Monaco', 'Consolas', monospace;
+    font-size: 0.8em;
+    border-radius: 6px;
+    margin: 1em 0;
+    padding: 1em;
+    overflow-x: auto;
+    /* 혹시 border가 필요하면 아래 추가 */
+    /* border: 1px solidrgb(67, 63, 96); */
+  }
+`;

--- a/src/styles/table.css
+++ b/src/styles/table.css
@@ -1,0 +1,44 @@
+.notion-table-of-contents {
+  position: fixed;
+  right: -75%;
+  top: 80px;
+  display: flex;
+  flex-direction: column;
+}
+
+@media screen and (max-width: 1800px) {
+  .notion-table-of-contents {
+    right: -80%;
+  }
+}
+
+@media screen and (max-width: 1500px) {
+  .notion-table-of-contents {
+    position: static;
+  }
+}
+
+.notion-table-of-contents a {
+  padding: 0;
+  margin-bottom: 10px;
+}
+
+.notion-table-of-contents a:hover {
+  background: none;
+}
+
+.notion-table-of-contents span {
+  padding: 2px 2px;
+  line-height: 1.3;
+  background: linear-gradient(
+    to right,
+    rgba(255, 255, 255, 0) 50%,
+    var(--bg-color-0) 50%
+  );
+  background-size: 200%;
+  transition: 0.35s;
+}
+
+.notion-table-of-contents span:hover {
+  background-position: -100% 0;
+} 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3426,6 +3426,11 @@ prettier@^2.7.1:
   resolved "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
+prism-material-themes@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/prism-material-themes/-/prism-material-themes-1.0.5.tgz#7034e8196bfcca6cda930d5bdaf8fd2229149352"
+  integrity sha512-idTEXmj7rajdOWuiXybh/FrrT/Byg4YTr/q4FgmKNiXVpreNKU8AjpY8feF96Q1bvcblJ3DJnFNMX7tt7S1l1Q==
+
 prismjs@^1.27.0, prismjs@^1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.30.0.tgz#d9709969d9d4e16403f6f348c63553b19f0975a9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,6 +57,11 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@babel/runtime@^7.3.1":
+  version "7.27.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.6.tgz#ec4070a04d76bae8ddbb10770ba55714a417b7c6"
+  integrity sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==
+
 "@babel/types@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.22.5.tgz#cd93eeaab025880a3a47ec881f4b096a5b786fbe"
@@ -397,6 +402,13 @@
   version "0.0.12"
   resolved "https://registry.yarnpkg.com/@types/gtag.js/-/gtag.js-0.0.12.tgz#095122edca896689bdfcdd73b057e23064d23572"
   integrity sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg==
+
+"@types/hast@^2.0.0":
+  version "2.3.10"
+  resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.10.tgz#5c9d9e0b304bbb8879b857225c5ebab2d81d7643"
+  integrity sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==
+  dependencies:
+    "@types/unist" "^2"
 
 "@types/json5@^0.0.29":
   version "0.0.29"
@@ -809,10 +821,25 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+character-entities-legacy@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz#94bc1845dce70a5bb9d2ecc748725661293d8fc1"
+  integrity sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==
+
+character-entities@^1.0.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.4.tgz#e12c3939b7eaf4e5b15e7ad4c5e28e1d48c5b16b"
+  integrity sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==
+
 character-entities@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-2.0.2.tgz#2d09c2e72cd9523076ccb21157dff66ad43fcc22"
   integrity sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==
+
+character-reference-invalid@^1.0.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
+  integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
 
 chownr@^1.1.1:
   version "1.1.4"
@@ -859,6 +886,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+comma-separated-tokens@^1.0.0:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
+  integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
 
 commander@7:
   version "7.2.0"
@@ -1815,6 +1847,13 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
+fault@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/fault/-/fault-1.0.4.tgz#eafcfc0a6d214fc94601e170df29954a4f842f13"
+  integrity sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==
+  dependencies:
+    format "^0.2.0"
+
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz"
@@ -1882,6 +1921,11 @@ form-data@^4.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
+
+format@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
+  integrity sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==
 
 fraction.js@^4.2.0:
   version "4.2.0"
@@ -2105,6 +2149,32 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hast-util-parse-selector@^2.0.0:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz#d57c23f4da16ae3c63b3b6ca4616683313499c3a"
+  integrity sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==
+
+hastscript@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-6.0.0.tgz#e8768d7eac56c3fdeac8a92830d58e811e5bf640"
+  integrity sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    comma-separated-tokens "^1.0.0"
+    hast-util-parse-selector "^2.0.0"
+    property-information "^5.0.0"
+    space-separated-tokens "^1.0.0"
+
+highlight.js@^10.4.1, highlight.js@~10.7.0:
+  version "10.7.3"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
+  integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
+
+highlightjs-vue@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz#fdfe97fbea6354e70ee44e3a955875e114db086d"
+  integrity sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==
+
 hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
@@ -2205,6 +2275,19 @@ invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
+is-alphabetical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.4.tgz#9e7d6b94916be22153745d184c298cbf986a686d"
+  integrity sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==
+
+is-alphanumerical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz#7eb9a2431f855f6b1ef1a78e326df515696c4dbf"
+  integrity sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+
 is-array-buffer@^3.0.1, is-array-buffer@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.2.tgz#f2653ced8412081638ecb0ebbd0c41c6e0aecbbe"
@@ -2265,6 +2348,11 @@ is-date-object@^1.0.1:
   dependencies:
     has-tostringtag "^1.0.0"
 
+is-decimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.4.tgz#65a3a5958a1c5b63a706e1b333d7cd9f630d3fa5"
+  integrity sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==
+
 is-docker@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
@@ -2286,6 +2374,11 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-hexadecimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
+  integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
 
 is-inside-container@^1.0.0:
   version "1.0.0"
@@ -2527,6 +2620,14 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
+
+lowlight@^1.17.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/lowlight/-/lowlight-1.20.0.tgz#ddb197d33462ad0d93bf19d17b6c301aa3941888"
+  integrity sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==
+  dependencies:
+    fault "^1.0.0"
+    highlight.js "~10.7.0"
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -3203,6 +3304,18 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse-entities@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-2.0.0.tgz#53c6eb5b9314a1f4ec99fa0fdf7ce01ecda0cbe8"
+  integrity sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
 parse-json@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
@@ -3313,15 +3426,20 @@ prettier@^2.7.1:
   resolved "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
+prismjs@^1.27.0, prismjs@^1.30.0:
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.30.0.tgz#d9709969d9d4e16403f6f348c63553b19f0975a9"
+  integrity sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==
+
 prismjs@^1.29.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
   integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==
 
-prismjs@^1.30.0:
-  version "1.30.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.30.0.tgz#d9709969d9d4e16403f6f348c63553b19f0975a9"
-  integrity sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==
+prismjs@~1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
+  integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
 
 prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
@@ -3331,6 +3449,13 @@ prop-types@^15.7.2, prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+property-information@^5.0.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-5.6.0.tgz#61675545fb23002f245c6540ec46077d4da3ed69"
+  integrity sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==
+  dependencies:
+    xtend "^4.0.0"
 
 pump@^3.0.0:
   version "3.0.0"
@@ -3462,6 +3587,18 @@ react-pdf@^9.2.1:
     tiny-invariant "^1.0.0"
     warning "^4.0.0"
 
+react-syntax-highlighter@^15.6.1:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-15.6.1.tgz#fa567cb0a9f96be7bbccf2c13a3c4b5657d9543e"
+  integrity sha512-OqJ2/vL7lEeV5zTJyG7kmARppUjiB9h9udl4qHQjjgEos66z00Ia0OckwYfRxCSFrW8RJIBnsBwQsHZbVPspqg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    highlight.js "^10.4.1"
+    highlightjs-vue "^1.0.0"
+    lowlight "^1.17.0"
+    prismjs "^1.27.0"
+    refractor "^3.6.0"
+
 react@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
@@ -3477,6 +3614,15 @@ readable-stream@^3.1.1, readable-stream@^3.4.0:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+refractor@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/refractor/-/refractor-3.6.0.tgz#ac318f5a0715ead790fcfb0c71f4dd83d977935a"
+  integrity sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==
+  dependencies:
+    hastscript "^6.0.0"
+    parse-entities "^2.0.0"
+    prismjs "~1.27.0"
 
 regenerator-runtime@^0.13.11:
   version "0.13.11"
@@ -3679,6 +3825,11 @@ source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
+
+space-separated-tokens@^1.0.0:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz#85f32c3d10d9682007e917414ddc5c26d1aa6899"
+  integrity sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==
 
 streamsearch@^1.1.0:
   version "1.1.0"
@@ -4063,6 +4214,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+xtend@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Description

- **Pinned Posts 기능 추가**
  - PinnedPosts 컴포넌트 및 filterPosts 함수 구현
  - Feed에서 상단에 Pinned Posts 노출

- **NotionRenderer 스타일 분리 및 개선**
  - 기존 StyledWrapper의 Notion 관련 CSS를 `src/styles/notion-custom.ts`로 분리, emotion Global로 적용
  - 코드 블럭(`.notion-code`, `.notion-code code`)에 atom one light 스타일(밝은 배경, 어두운 글자) 적용
  - 코드 하이라이트 테마를 prism-themes(material, atom-one-light 등)로 교체 및 실험
  - 코드 블럭 내부 구조에 맞춰 배경색/글자색이 겹치지 않도록 CSS 수정

- **코드 하이라이트 적용**
  - PrismJS highlightAll()을 NotionRenderer에서 recordMap 변경 시마다 적용
  - 필요 없는 테마 import(예: atom-one-light) 제거

- **기타**
  - 글로벌 스타일에서 코드 하이라이트 색상 덮어쓰는 문제 없는지 검토 및 안내
  - yarn add로 설치한 prism-themes 등 패키지 삭제 방법 안내

---

## Related tickets

https://github.com/morethanmin/morethan-log/issues/XX

---

## PR Checklist

- [x] I have read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I have written documents and tests, if needed.

---

### 스크린샷/비주얼

- 코드 블럭이 prism-material-themes/themes/material-default 스타일로 잘 보임
