### PR TITLE
[fix]: Notion 리스트 들여쓰기 개선 및 계층별 스타일 적용

### DIFF
--- a/src/styles/notion-custom.ts
+++ b/src/styles/notion-custom.ts
@@ -51,4 +51,20 @@ export const notionCustomStyles = css`
     white-space: pre;
     -webkit-overflow-scrolling: touch;
   }
+  /* 최상위 리스트는 들여쓰기 없음 */
+  .notion-list > ol,
+  .notion-list > ul {
+    margin-left: 0 !important;
+    padding-left: 0 !important;
+    list-style-position: inside !important;
+  }
+  /* 하위(subset) 리스트는 들여쓰기 적용 */
+  .notion-list ol ol,
+  .notion-list ul ul,
+  .notion-list ol ul,
+  .notion-list ul ol {
+    margin-left: 0 !important;
+    padding-left: 0.7em !important;
+    list-style-position: inside !important;
+  }
 `;


### PR DESCRIPTION
## Description

- Notion에서 변환된 리스트(ol, ul)의 들여쓰기 스타일을 개선했습니다.
- **최상위 리스트**는 들여쓰기 없이 화면 왼쪽에 붙어서 시작하도록 수정했습니다.
- **하위(subset) 리스트**(중첩 리스트)는 적당한 들여쓰기가 적용되도록 CSS를 분리 적용했습니다.
- `padding-left` 값을 0.7em으로 조정하여, 리스트 번호/불릿과 텍스트가 너무 멀어지지 않게 했습니다.
- 결과적으로 리스트 계층 구조가 더 명확하게 보이고, 가독성이 향상되었습니다.

### 주요 변경점
- `src/styles/notion-custom.ts`에서 리스트 관련 CSS를 다음과 같이 변경:
  - `.notion-list > ol`, `.notion-list > ul` : 들여쓰기 없음
  - 중첩 리스트(`ol ol`, `ul ul`, `ol ul`, `ul ol`) : `padding-left: 0.7em`
- 기존의 모든 리스트에 일괄적으로 들여쓰기를 적용하던 방식을 계층별로 분리

---

## Related tickets

(이슈가 있다면 링크 추가)
예시: https://github.com/morethanmin/morethan-log/issues/XX

---

## PR Checklist

- [x] I have read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I have tested the UI to ensure 리스트 들여쓰기가 정상적으로 동작함을 확인했습니다.

---

### 스크린샷/비주얼

- 최상위 리스트는 왼쪽에 붙어서 시작
- 하위 리스트는 적당히 들여쓰기 적용
- 리스트 번호/불릿과 텍스트 간격이 자연스러움
