### PR TITLE
[fix]: Notion 테이블/리스트/구분선 스타일 개선

### DIFF
--- a/src/styles/notion-custom.ts
+++ b/src/styles/notion-custom.ts
@@ -18,6 +18,8 @@ export const notionCustomStyles = css`
     -webkit-overflow-scrolling: touch;
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;
+    border: none !important;
+    border-collapse: collapse !important;
   }
   .notion-simple-table > tbody,
   .notion-simple-table > thead {
@@ -31,6 +33,7 @@ export const notionCustomStyles = css`
     word-break: break-word;
     padding: 8px;
     vertical-align: top;
+    border: 1px solid #d1d5db !important;
   }
   .notion-quote {
     font-size: 1rem;

--- a/src/styles/notion-custom.ts
+++ b/src/styles/notion-custom.ts
@@ -58,16 +58,14 @@ export const notionCustomStyles = css`
   .notion-list > ol,
   .notion-list > ul {
     margin-left: 0 !important;
-    padding-left: 0 !important;
-    list-style-position: inside !important;
+    padding-left: 1.3em !important;
   }
-  /* 하위(subset) 리스트는 들여쓰기 적용 */
-  .notion-list ol ol,
-  .notion-list ul ul,
-  .notion-list ol ul,
-  .notion-list ul ol {
-    margin-left: 0 !important;
-    padding-left: 0.7em !important;
-    list-style-position: inside !important;
+  /* 첫 번째 리스트 항목만 왼쪽 패딩 제거 */
+  .notion-list > ol > li:first-child,
+  .notion-list > ul > li:first-child {
+    padding-left: 0 !important;
+  }
+  .notion-hr {
+    margin: 2em 0 !important;
   }
 `;


### PR DESCRIPTION
## Description

- Notion에서 변환된 테이블의 상하단 이중 테두리 현상을 해결했습니다.
  - 테이블에는 border를 제거하고, 셀(th, td)에만 border를 적용하여 한 겹의 테두리만 보이도록 수정
  - `border-collapse: collapse` 적용
- 리스트(ol, ul) 스타일을 개선했습니다.
  - 최상위 리스트는 들여쓰기 최소화, 첫 번째 항목은 왼쪽 패딩 제거
  - 하위 리스트는 적당한 들여쓰기가 적용되도록 조정
- 구분선(`<hr>`)에 위아래 마진을 추가하여 시각적으로 더 넉넉하게 띄워지도록 개선
- 기타 Notion 관련 요소의 스타일을 전반적으로 다듬어 가독성과 일관성을 높임

---

## Related tickets

(이슈가 있다면 링크 추가)
예시: https://github.com/morethanmin/morethan-log/issues/XX

---

## PR Checklist

- [x] I have read the [Contributing Guide](./CONTRIBUTING.md)
- [x] UI에서 테이블, 리스트, 구분선이 정상적으로 보이는지 직접 확인했습니다.
