### PR TITLE
feat: Notion 토글 및 주요 블록 글로벌 폰트 적용 개선

### DIFF
--- a/src/layouts/RootLayout/index.tsx
+++ b/src/layouts/RootLayout/index.tsx
@@ -93,14 +93,16 @@ const RootLayout = ({ children }: Props) => {
   return (
     <ThemeProvider scheme={scheme}>
       <Scripts />
-      {/* // TODO: replace react query */}
-      {/* {metaConfig.type !== "Paper" && <Header />} */}
-      <Header fullWidth={false} />
-      {/* 네비게이션 바로 아래 스크롤 프로그레스바 */}
-      <ProgressBarWrapper>
-        <ProgressBarInner style={{ width: `${getCurrentPercentage()}%` }} />
-      </ProgressBarWrapper>
-      <StyledMain ref={currentElementRef}>{children}</StyledMain>
+      <div style={{ fontFamily: '"Noto Serif KR", "PingFang SC", "Microsoft YaHei", sans-serif' }}>
+        {/* // TODO: replace react query */}
+        {/* {metaConfig.type !== "Paper" && <Header />} */}
+        <Header fullWidth={false} />
+        {/* 네비게이션 바로 아래 스크롤 프로그레스바 */}
+        <ProgressBarWrapper>
+          <ProgressBarInner style={{ width: `${getCurrentPercentage()}%` }} />
+        </ProgressBarWrapper>
+        <StyledMain ref={currentElementRef}>{children}</StyledMain>
+      </div>
     </ThemeProvider>
   )
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,16 +3,25 @@ import { Hydrate, QueryClientProvider } from "@tanstack/react-query"
 import { RootLayout } from "src/layouts"
 import { queryClient } from "src/libs/react-query"
 import "src/styles/table.css"
+import Head from "next/head"
+import { Global } from "@emotion/react"
+import { notionCustomStyles } from "src/styles/notion-custom"
 
 function App({ Component, pageProps }: AppPropsWithLayout) {
   const getLayout = Component.getLayout || ((page) => page)
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <Hydrate state={pageProps.dehydratedState}>
-        <RootLayout>{getLayout(<Component {...pageProps} />)}</RootLayout>
-      </Hydrate>
-    </QueryClientProvider>
+    <>
+      <Head>
+        <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+KR:wght@400;700&display=swap" rel="stylesheet" />
+      </Head>
+      <Global styles={notionCustomStyles} />
+      <QueryClientProvider client={queryClient}>
+        <Hydrate state={pageProps.dehydratedState}>
+          <RootLayout>{getLayout(<Component {...pageProps} />)}</RootLayout>
+        </Hydrate>
+      </QueryClientProvider>
+    </>
   )
 }
 

--- a/src/styles/notion-custom.ts
+++ b/src/styles/notion-custom.ts
@@ -56,16 +56,43 @@ export const notionCustomStyles = css`
   }
   /* 최상위 리스트는 들여쓰기 없음 */
   .notion-list > ol,
-  .notion-list > ul {
+  .notion-list > ul,
+  .notion-list-numbered > ol,
+  .notion-list-numbered > ul {
     margin-left: 0 !important;
     padding-left: 1.3em !important;
   }
   /* 첫 번째 리스트 항목만 왼쪽 패딩 제거 */
   .notion-list > ol > li:first-child,
-  .notion-list > ul > li:first-child {
+  .notion-list > ul > li:first-child,
+  .notion-list-numbered > ol > li:first-child,
+  .notion-list-numbered > ul > li:first-child {
     padding-left: 0 !important;
   }
   .notion-hr {
     margin: 2em 0 !important;
   }
+  .notion-code,
+  .notion-inline-code {
+    font-family: 'Fira Mono', 'Menlo', 'Monaco', 'Consolas', monospace !important;
+  }
+  /* 나머지 텍스트에만 글로벌 폰트 적용 */
+  .notion-toggle,
+  .notion-toggle-button,
+  .notion-toggle-button-arrow,
+  .notion-toggle-button-arrow-opened,
+  .notion-toggle-content,
+  .notion-simple-table,
+  .notion-table-of-contents,
+  .notion-text,
+  .notion-list,
+  .notion-h1,
+  .notion-h2,
+  .notion-h3,
+  .notion-quote,
+  .notion-callout {
+    font-family: "Noto Serif KR", "PingFang SC", "Microsoft YaHei", sans-serif !important;
+  }
+
+
 `;


### PR DESCRIPTION
## Description

- Notion의 토글 블록(제목, 버튼, 화살표, 내용 등)에 글로벌 폰트(`"Noto Serif KR", "PingFang SC", "Microsoft YaHei", sans-serif"`)가 일관되게 적용되도록 CSS를 개선했습니다.
- `.notion-toggle`, `.notion-toggle-button`, `.notion-toggle-button-arrow`, `.notion-toggle-button-arrow-opened`, `.notion-toggle-content` 등 토글 관련 클래스를 글로벌 폰트 적용 대상에 추가했습니다.
- 코드블럭(`.notion-code`, `.notion-inline-code`)에는 모노스페이스 폰트가 계속 적용되도록 분리 유지했습니다.
- 그 외 본문, 리스트, 테이블, 콜아웃 등 주요 블록에도 글로벌 폰트가 일관되게 적용됩니다.

---

## Related tickets

(이슈가 있다면 링크 추가)
예시: https://github.com/morethanmin/morethan-log/issues/XX

---

## PR Checklist

- [x] I have read the [Contributing Guide](./CONTRIBUTING.md)
- [x] Notion 토글 및 주요 블록에 폰트가 정상적으로 적용되는지 직접 확인했습니다.
