### PR TITLE
[fix]: Notion 리스트 및 테이블 스타일 개선

### DIFF
--- a/src/styles/notion-custom.ts
+++ b/src/styles/notion-custom.ts
@@ -49,7 +49,7 @@ export const notionCustomStyles = css`
   }
   /* 테이블 셀 텍스트 크기 통일 */
   .notion-simple-table-cell {
-    font-size: 1rem !important;
+    font-size: 0.9rem !important;
     line-height: 1.5 !important;
   }
   .notion-quote {

--- a/src/styles/notion-custom.ts
+++ b/src/styles/notion-custom.ts
@@ -47,6 +47,11 @@ export const notionCustomStyles = css`
     vertical-align: top;
     border: 1px solid #d1d5db !important;
   }
+  /* 테이블 셀 텍스트 크기 통일 */
+  .notion-simple-table-cell {
+    font-size: 1rem !important;
+    line-height: 1.5 !important;
+  }
   .notion-quote {
     font-size: 1rem;
     margin-top: 0.5rem;

--- a/src/styles/notion-custom.ts
+++ b/src/styles/notion-custom.ts
@@ -10,6 +10,18 @@ export const notionCustomStyles = css`
   .notion-list {
     width: 100%;
   }
+  /* 리스트 아이템 텍스트 줄바꿈 처리 */
+  .notion-list li {
+    word-wrap: break-word;
+    word-break: break-word;
+    overflow-wrap: break-word;
+    max-width: 100%;
+  }
+  .notion-list li > div {
+    width: 100%;
+    overflow-wrap: break-word;
+    word-break: break-word;
+  }
   /* 모바일 테이블 가로 스크롤 */
   .notion-simple-table {
     width: 100%;


### PR DESCRIPTION
## Description

Notion 렌더링 시 발생하는 두 가지 레이아웃 이슈를 수정했습니다:

1. 리스트 텍스트 오버플로우 문제
   - 긴 텍스트가 있을 때 화면을 벗어나는 문제 해결
   - word-wrap, word-break, overflow-wrap 속성을 추가하여 자동 줄바꿈 처리

2. 테이블 셀 텍스트 크기 불일치 문제
   - 모바일 화면에서 특정 셀의 텍스트 크기가 다른 셀과 달라지는 문제 해결
   - 모든 테이블 셀의 font-size를 1rem으로 통일
   - line-height를 1.5로 설정하여 가독성 개선

## Related tickets

https://github.com/morethanmin/morethan-log/issues/XX

## PR Checklist

- [x] I have read the [Contributing Guide](./CONTRIBUTING.md)
- [x] I have written documents and tests, if needed.