### PR TITLE
feat: 대분류/소분류 카테고리 시스템 구현 및 검색 개선

### DIFF
--- a/src/libs/utils/category.ts
+++ b/src/libs/utils/category.ts
@@ -21,6 +21,9 @@ export const getMajorCategoriesFromPosts = (posts: TPost[]): TMajorCategories =>
   posts.forEach(post => {
     if (!post.category) return
 
+    // 포스트별로 대분류를 한 번만 카운트하기 위해 Set 사용
+    const majorCategoriesInPost = new Set<string>()
+    
     post.category.forEach(categoryStr => {
       const { major, minor } = parseCategoryHierarchy(categoryStr)
       
@@ -31,7 +34,8 @@ export const getMajorCategoriesFromPosts = (posts: TPost[]): TMajorCategories =>
         }
       }
 
-      majorCategories[major].count++
+      // 대분류를 Set에 추가 (중복 방지)
+      majorCategoriesInPost.add(major)
 
       if (minor) {
         if (!majorCategories[major].minorCategories[minor]) {
@@ -39,6 +43,11 @@ export const getMajorCategoriesFromPosts = (posts: TPost[]): TMajorCategories =>
         }
         majorCategories[major].minorCategories[minor]++
       }
+    })
+
+    // 포스트에 포함된 각 대분류의 카운트를 1씩 증가
+    majorCategoriesInPost.forEach(major => {
+      majorCategories[major].count++
     })
   })
 

--- a/src/libs/utils/notion/getPageProperties.ts
+++ b/src/libs/utils/notion/getPageProperties.ts
@@ -39,7 +39,20 @@ async function getPageProperties(
         case "select": {
           const selects = getTextContent(val)
           if (selects[0]?.length) {
-            properties[schema[key].name] = selects.split(",")
+            const categories = selects.split(",")
+            const expandedCategories = new Set(categories)
+            
+            // '/' 구분자가 있는 카테고리에서 대분류도 추가
+            categories.forEach(category => {
+              if (category.includes('/')) {
+                const majorCategory = category.split('/')[0]?.trim()
+                if (majorCategory) {
+                  expandedCategories.add(majorCategory)
+                }
+              }
+            })
+            
+            properties[schema[key].name] = Array.from(expandedCategories)
           }
           break
         }

--- a/src/routes/Feed/PostList/filterPosts.tsx
+++ b/src/routes/Feed/PostList/filterPosts.tsx
@@ -1,6 +1,5 @@
 import { DEFAULT_CATEGORY } from "src/constants"
 import { TPost } from "src/types"
-import { parseCategoryHierarchy } from "src/libs/utils/category"
 
 interface FilterPostsParams {
   posts: TPost[]
@@ -12,17 +11,16 @@ interface FilterPostsParams {
 
 function matchesCategory(postCategories: string[], targetCategory: string): boolean {
   return postCategories.some(postCat => {
+    // 정확한 매치
     if (postCat === targetCategory) return true
     
-    const postHierarchy = parseCategoryHierarchy(postCat)
-    const targetHierarchy = parseCategoryHierarchy(targetCategory)
+    // '/' 구분으로 첫 번째 요소 비교 (대분류 매치)
+    const postFirstPart = postCat.split('/')[0]?.trim()
+    const targetFirstPart = targetCategory.split('/')[0]?.trim()
     
-    if (!targetHierarchy.minor) {
-      return postHierarchy.major === targetHierarchy.major
-    }
+    if (postFirstPart === targetFirstPart) return true
     
-    return postHierarchy.major === targetHierarchy.major && 
-           postHierarchy.minor === targetHierarchy.minor
+    return false
   })
 }
 


### PR DESCRIPTION
🎯 Summary
대분류 클릭 시 해당 대분류의 모든 소분류 글을 포함하여 검색되도록 개선

카테고리 개수 계산 시 중복을 제거하여 정확한 포스트 수를 표시

Notion에서 Infra/Kubernetes와 같이 /로 구분된 카테고리를 입력하면, 자동으로 대분류(Infra)를 추가

🔧 주요 변경사항
카테고리 자동 확장: /로 구분된 카테고리 입력 시 대분류를 자동 생성

카테고리 필터링 개선: 대분류 선택 시 모든 소분류의 포스트가 포함되도록 로직 개선

중복 카운트 방지: 포스트별 중복 카운트를 제거하여 정확한 카테고리 개수 제공

🛠 기술적 구현
getPageProperties.ts: select 타입의 카테고리 처리 시 대분류 자동 추가

filterPosts.tsx: 카테고리 필터링 로직 단순화, 대분류 필터링 지원

category.ts: Set을 사용해 중복 없이 카테고리별 포스트 수 계산

✅ 테스트 항목
 Infra/Kubernetes 포스트가 category=Infra로 검색되는지 확인

 카테고리별 포스트 개수가 중복 없이 정확히 표시되는지 확인

 기존 카테고리 검색 기능이 정상 작동하는지 확인